### PR TITLE
feat: Adds .keys() method for retrieving all keys

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -472,7 +472,23 @@ where
         }
     }
 
+    /// Retrieve all keys from ART.
+    ///
+    /// # Examples:
+    /// ```
+    /// use congee::Congee;
+    /// let tree = Congee::default();
+    /// let guard = tree.pin();
+    /// tree.insert(1, 42, &guard);
+    /// tree.insert(2, 43, &guard);
+    ///
+    /// let keys = tree.keys();
+    /// assert_eq!(keys, vec![1, 2]);
+    /// ```
     pub fn keys(&self) -> Vec<K> {
-        self.inner.keys().into_iter().map(|k| K::from(k)).collect()
+        self.inner.keys().into_iter().map(|k| {
+            let key = usize::from_be_bytes(k);
+            K::from(key)
+        }).collect()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ mod stats;
 #[cfg(test)]
 mod tests;
 
-use std::{marker::PhantomData, sync::Arc};
+use std::{marker::PhantomData, sync::Arc, usize};
 
 use error::OOMError;
 use tree::RawCongee;
@@ -470,5 +470,9 @@ where
             }
             None => Err(None),
         }
+    }
+
+    pub fn keys(&self) -> Vec<K> {
+        self.inner.keys().into_iter().map(|k| K::from(k)).collect()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ mod stats;
 #[cfg(test)]
 mod tests;
 
-use std::{marker::PhantomData, sync::Arc, usize};
+use std::{marker::PhantomData, sync::Arc};
 
 use error::OOMError;
 use tree::RawCongee;
@@ -486,9 +486,13 @@ where
     /// assert_eq!(keys, vec![1, 2]);
     /// ```
     pub fn keys(&self) -> Vec<K> {
-        self.inner.keys().into_iter().map(|k| {
-            let key = usize::from_be_bytes(k);
-            K::from(key)
-        }).collect()
+        self.inner
+            .keys()
+            .into_iter()
+            .map(|k| {
+                let key = usize::from_be_bytes(k);
+                K::from(key)
+            })
+            .collect()
     }
 }

--- a/src/tests/tree.rs
+++ b/src/tests/tree.rs
@@ -43,7 +43,7 @@ fn test_get_keys() {
         let v = tree.get(&k, &guard).unwrap();
         values_from_keys.push(v);
     }
-    
+
     assert_eq!(values, values_from_keys);
 }
 

--- a/src/tests/tree.rs
+++ b/src/tests/tree.rs
@@ -22,6 +22,20 @@ fn small_insert() {
 }
 
 #[test]
+fn test_get_keys() {
+    let key_cnt = 10_000usize;
+    let tree = RawCongee::default();
+
+    let guard = crossbeam_epoch::pin();
+    for k in 0..key_cnt {
+        let key: [u8; 8] = k.to_be_bytes();
+        tree.insert(&key, k, &guard).unwrap();
+        let v = tree.get(&key, &guard).unwrap();
+        assert_eq!(v, k);
+    }
+}
+
+#[test]
 fn test_sparse_keys() {
     use crate::utils::leak_check::LeakCheckAllocator;
     let key_cnt = 100_000;

--- a/src/tests/tree.rs
+++ b/src/tests/tree.rs
@@ -24,6 +24,8 @@ fn small_insert() {
 #[test]
 fn test_get_keys() {
     let key_cnt = 10_000usize;
+    let mut values = vec![];
+    let mut values_from_keys = vec![];
     let tree = RawCongee::default();
 
     let guard = crossbeam_epoch::pin();
@@ -31,8 +33,18 @@ fn test_get_keys() {
         let key: [u8; 8] = k.to_be_bytes();
         tree.insert(&key, k, &guard).unwrap();
         let v = tree.get(&key, &guard).unwrap();
-        assert_eq!(v, k);
+        values.push(v);
     }
+
+    let keys = tree.keys();
+    assert_eq!(keys.len(), key_cnt);
+
+    for k in keys.into_iter() {
+        let v = tree.get(&k, &guard).unwrap();
+        values_from_keys.push(v);
+    }
+    
+    assert_eq!(values, values_from_keys);
 }
 
 #[test]

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -162,7 +162,6 @@ impl<const K_LEN: usize, A: Allocator + Clone + Send> RawCongee<K_LEN, A> {
     }
 
     pub(crate) fn keys(&self) -> Vec<[u8; K_LEN]> {
-        let mut keys: Vec<[u8; K_LEN]> = Vec::new();
         loop {
             let mut visitor = LeafNodeKeyVisitor::<K_LEN> { keys: Vec::new() };
             if self.dfs_visitor_slow(&mut visitor).is_ok() {


### PR DESCRIPTION
This PR adds a helper method to get all keys from the tree. It will assist with https://github.com/XiangpengHao/liquid-cache/issues/181#issuecomment-2852599885. 

Right now it returns a `Vec<K>` another option is to return an `impl Iterator<K>`.

Closes https://github.com/XiangpengHao/congee/issues/24