### PR TITLE
Improve Congee Stats

### DIFF
--- a/src/congee.rs
+++ b/src/congee.rs
@@ -465,6 +465,11 @@ where
             Ok(None)
         }
     }
+
+    /// Display the internal node statistics
+    pub fn stats(&self) -> crate::stats::NodeStats {
+        self.inner.stats()
+    }
 }
 
 #[cfg(test)]

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -16,7 +16,6 @@ pub struct NodeStats {
 }
 
 impl NodeStats {
-
     pub fn total_memory_bytes(&self) -> usize {
         self.levels.values().map(|l| l.memory_size()).sum()
     }
@@ -60,7 +59,7 @@ impl Display for NodeStats {
 
         fn format_memory(bytes: usize) -> String {
             if bytes < 1024 {
-                format!("{} B", bytes)
+                format!("{bytes} B")
             } else if bytes < 1024 * 1024 {
                 format!("{:.1} KB", bytes as f64 / 1024.0)
             } else if bytes < 1024 * 1024 * 1024 {
@@ -78,9 +77,18 @@ impl Display for NodeStats {
         let mut memory_size = 0;
         let mut value_count = 0;
 
-        writeln!(f, "╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────╮")?;
-        writeln!(f, "│                                            Congee Statistics                                                 │")?;
-        writeln!(f, "├──────────────────────────────────────────────────────────────────────────────────────────────────────────────┤")?;
+        writeln!(
+            f,
+            "╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────╮"
+        )?;
+        writeln!(
+            f,
+            "│                                            Congee Statistics                                                 │"
+        )?;
+        writeln!(
+            f,
+            "├──────────────────────────────────────────────────────────────────────────────────────────────────────────────┤"
+        )?;
 
         for l in levels.iter() {
             total_f += l.n4.value_count as f64 / 4.0;
@@ -110,42 +118,69 @@ impl Display for NodeStats {
             )?;
         }
 
-        writeln!(f, "├──────────────────────────────────────────────────────────────────────────────────────────────────────────────┤")?;
-        
+        writeln!(
+            f,
+            "├──────────────────────────────────────────────────────────────────────────────────────────────────────────────┤"
+        )?;
+
         let total_mem_str = format_memory(memory_size);
-        writeln!(f, "│ Total Memory: {:>10} │ Entries: {:>8} │ KV Pairs: {:>8}                                            │", 
-            total_mem_str, value_count, self.kv_pairs)?;
+        writeln!(
+            f,
+            "│ Total Memory: {:>10} │ Entries: {:>8} │ KV Pairs: {:>8}                                            │",
+            total_mem_str, value_count, self.kv_pairs
+        )?;
 
         // Node count breakdown by type
         let n4_count: usize = levels.iter().map(|l| l.n4.node_count).sum();
         let n16_count: usize = levels.iter().map(|l| l.n16.node_count).sum();
         let n48_count: usize = levels.iter().map(|l| l.n48.node_count).sum();
         let n256_count: usize = levels.iter().map(|l| l.n256.node_count).sum();
-        
-        writeln!(f, "│ Node Counts:  {:>10} │ N4: {:>8} │ N16: {:>8} │ N48: {:>8} │ N256: {:>8}                     │", 
-            node_count, n4_count, n16_count, n48_count, n256_count)?;
 
-        let load_factor = if node_count > 0 { total_f / (node_count as f64) } else { 0.0 };
-        let load_status = if load_factor < 0.5 && node_count > 0 { " (low)" } else { "" };
+        writeln!(
+            f,
+            "│ Node Counts:  {node_count:>10} │ N4: {n4_count:>8} │ N16: {n16_count:>8} │ N48: {n48_count:>8} │ N256: {n256_count:>8}                     │"
+        )?;
+
+        let load_factor = if node_count > 0 {
+            total_f / (node_count as f64)
+        } else {
+            0.0
+        };
+        let load_status = if load_factor < 0.5 && node_count > 0 {
+            " (low)"
+        } else {
+            ""
+        };
         let n4_mem = format_memory(n4_count * 56);
         let n16_mem = format_memory(n16_count * 160);
         let n48_mem = format_memory(n48_count * 664);
         let n256_mem = format_memory(n256_count * 2096);
-        
-        writeln!(f, "│ Load Factor: {:4.2}{:<6} │ N4: {:<8} │ N16: {:<8} │ N48: {:<8} │ N256: {:<8}                      │", 
-            load_factor, load_status, n4_mem, n16_mem, n48_mem, n256_mem)?;
-        
-        writeln!(f, "├──────────────────────────────────────────────────────────────────────────────────────────────────────────────┤")?;
-        writeln!(f, "│                                            Prefix Length Distribution                                        │")?;
-        writeln!(f, "├──────────────────────────────────────────────────────────────────────────────────────────────────────────────┤")?;
-        
+
+        writeln!(
+            f,
+            "│ Load Factor: {load_factor:4.2}{load_status:<6} │ N4: {n4_mem:<8} │ N16: {n16_mem:<8} │ N48: {n48_mem:<8} │ N256: {n256_mem:<8}                      │"
+        )?;
+
+        writeln!(
+            f,
+            "├──────────────────────────────────────────────────────────────────────────────────────────────────────────────┤"
+        )?;
+        writeln!(
+            f,
+            "│                                            Prefix Length Distribution                                        │"
+        )?;
+        writeln!(
+            f,
+            "├──────────────────────────────────────────────────────────────────────────────────────────────────────────────┤"
+        )?;
+
         write!(f, "│ All │")?;
         for i in 0..=7 {
             write!(f, " {}:{:>7} │", i, self.prefix_distribution[i])?;
         }
         write!(f, " {}:{:>1}    │", 8, self.prefix_distribution[8])?;
-        writeln!(f, "")?;
-        
+        writeln!(f)?;
+
         // Per-level prefix distribution
         for l in levels.iter() {
             write!(f, "│ L{:>2} │", l.level)?;
@@ -153,10 +188,13 @@ impl Display for NodeStats {
                 write!(f, " {}:{:>7} │", i, l.prefix_distribution[i])?;
             }
             write!(f, " {}:{:>1}    │", 8, l.prefix_distribution[8])?;
-            writeln!(f, "")?;
+            writeln!(f)?;
         }
 
-        writeln!(f, "╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────╯")?;
+        writeln!(
+            f,
+            "╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────╯"
+        )?;
 
         Ok(())
     }

--- a/src/tests/memory_stats.rs
+++ b/src/tests/memory_stats.rs
@@ -1,20 +1,20 @@
-use crate::{CongeeRaw};
+use crate::CongeeRaw;
 
 #[test]
 fn test_memory_stats_simple() {
     let tree = CongeeRaw::<usize, usize>::default();
     let guard = tree.pin();
-    
+
     // Empty tree will have a root node, which is 56 bytes
     let stats = tree.stats();
-    
+
     let empty_memory = stats.total_memory_bytes();
     assert_eq!(empty_memory, 56);
     assert_eq!(stats.kv_pairs(), 0);
-    
+
     tree.insert(1, 42, &guard).unwrap();
     let stats = tree.stats();
-    
+
     // After inserting one value, we should have more memory and at least one more node
     let memory_increase = stats.total_memory_bytes() - empty_memory;
     assert_eq!(memory_increase, 56);
@@ -26,17 +26,20 @@ fn test_memory_stats_simple() {
 fn test_memory_stats_expected_sizes() {
     let tree = CongeeRaw::<usize, usize>::default();
     let guard = tree.pin();
-    
-    tree.insert(0x1000, 1, &guard).unwrap(); 
-    tree.insert(0x2000, 2, &guard).unwrap();  // Different prefix
-    tree.insert(0x1001, 3, &guard).unwrap();  // Same prefix as first
-    
+
+    tree.insert(0x1000, 1, &guard).unwrap();
+    tree.insert(0x2000, 2, &guard).unwrap(); // Different prefix
+    tree.insert(0x1001, 3, &guard).unwrap(); // Same prefix as first
+
     let stats = tree.stats();
     let (n4_mem, n16_mem, n48_mem, n256_mem) = stats.memory_by_node_type();
-    
+
     // Verify the sum matches total
-    assert_eq!(stats.total_memory_bytes(), n4_mem + n16_mem + n48_mem + n256_mem);
-    
+    assert_eq!(
+        stats.total_memory_bytes(),
+        n4_mem + n16_mem + n48_mem + n256_mem
+    );
+
     assert!(stats.total_memory_bytes() > 0);
     assert_eq!(stats.kv_pairs(), 3);
 }

--- a/src/tests/memory_stats.rs
+++ b/src/tests/memory_stats.rs
@@ -1,0 +1,42 @@
+use crate::{CongeeRaw};
+
+#[test]
+fn test_memory_stats_simple() {
+    let tree = CongeeRaw::<usize, usize>::default();
+    let guard = tree.pin();
+    
+    // Empty tree will have a root node, which is 56 bytes
+    let stats = tree.stats();
+    
+    let empty_memory = stats.total_memory_bytes();
+    assert_eq!(empty_memory, 56);
+    assert_eq!(stats.kv_pairs(), 0);
+    
+    tree.insert(1, 42, &guard).unwrap();
+    let stats = tree.stats();
+    
+    // After inserting one value, we should have more memory and at least one more node
+    let memory_increase = stats.total_memory_bytes() - empty_memory;
+    assert_eq!(memory_increase, 56);
+    assert_eq!(stats.total_nodes(), 2);
+    assert_eq!(stats.kv_pairs(), 1);
+}
+
+#[test]
+fn test_memory_stats_expected_sizes() {
+    let tree = CongeeRaw::<usize, usize>::default();
+    let guard = tree.pin();
+    
+    tree.insert(0x1000, 1, &guard).unwrap(); 
+    tree.insert(0x2000, 2, &guard).unwrap();  // Different prefix
+    tree.insert(0x1001, 3, &guard).unwrap();  // Same prefix as first
+    
+    let stats = tree.stats();
+    let (n4_mem, n16_mem, n48_mem, n256_mem) = stats.memory_by_node_type();
+    
+    // Verify the sum matches total
+    assert_eq!(stats.total_memory_bytes(), n4_mem + n16_mem + n48_mem + n256_mem);
+    
+    assert!(stats.total_memory_bytes() > 0);
+    assert_eq!(stats.kv_pairs(), 3);
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -2,10 +2,10 @@ use std::sync::Arc;
 
 use crate::DefaultAllocator;
 
-mod scan;
-mod tree;
 mod alloc;
 mod memory_stats;
+mod scan;
+mod tree;
 
 #[test]
 fn drop_with_drainer() {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -4,8 +4,8 @@ use crate::DefaultAllocator;
 
 mod scan;
 mod tree;
-
 mod alloc;
+mod memory_stats;
 
 #[test]
 fn drop_with_drainer() {


### PR DESCRIPTION
Changes:
1) Add stats in congee.rs. Currently it is present only in raw and set
2) Add more useful functions related to memory usage
3) Add prefix distribution data
3) Prettify stats display
4) Add simple tests to verify the stats

Current stats format:

Level: 0 --- || N4:        0,     0.00 || N16:        0,     0.00 || N48:        0,     0.00 || N256:        1,     1.00 ||
Level: 1 --- || N4:        0,     0.00 || N16:        0,     0.00 || N48:        0,     0.00 || N256:      256,     1.00 ||
Level: 2 --- || N4:        0,     0.00 || N16:        0,     0.00 || N48:     4745,     0.97 || N256:    60791,     0.22 ||
Level: 3 --- || N4:  3635205,     0.28 || N16:       34,     0.31 || N48:        0,     0.00 || N256:        1,     0.66 ||
Level: 4 --- || N4:   708443,     0.25 || N16:        0,     0.00 || N48:        0,     0.00 || N256:      168,     1.00 ||
Level: 5 --- || N4:      398,     0.25 || N16:        0,     0.00 || N48:      386,     0.79 || N256:    42583,     0.34 ||
Overall node count: 4453011, entry count: 12164302
Load factor: 0.27 (too low)
Active memory usage: 442 Mb
KV count: 7711292

Proposed stats format:

<img width="808" height="339" alt="Screenshot 2025-08-22 at 7 33 22 PM" src="https://github.com/user-attachments/assets/0f1f7597-7a16-4244-9da8-9164e62ac3e4" />
